### PR TITLE
Added additional CSS path options for final challenge autograder

### DIFF
--- a/.guides/tests/final-challenge.js
+++ b/.guides/tests/final-challenge.js
@@ -13,30 +13,45 @@ var curr = fs.readFileSync(indexpath)
 
 if (orig.toString() !=  curr.toString()) {
   errors.push("You modified the index.html, it's not allowed")
-} 
+}
 
 var ast = cssutils.get_ast(stylepath);
 
 if (ast.ast == undefined) {
-  errors.push(stylepath + " doesn't exist or cannot be parsed"); 
+  errors.push(stylepath + " doesn't exist or cannot be parsed");
 } else {
-  
-  if (!ast.selector_has_property("#header-nav li ul","font-size","80%")) {
+
+  // Because we don't specify a CSS selector strategy in the challenge description,
+  // we need to be prepared for _at least_ those strategies we've introduced up
+  // to this point - that includes child and descendant relationships.
+  if (
+    // Descendant to the nested ul
+    !ast.selector_has_property("#header-nav li ul","font-size","80%")
+    // Descendant to the nested li
+    && !ast.selector_has_property("#header-nav li ul li", "font-size", "80%")
+    // Child to the nested ul
+    && !ast.selector_has_property("#header-nav>li>ul", "font-size", "80%")
+    // Child to the nested li
+    && !ast.selector_has_property("#header-nav>li>ul>li", "font-size", "80%")
+    // Mix of child and descendant
+    && !ast.selector_has_property("#header-nav li>ul", "font-size", "80%")
+    && !ast.selector_has_property("#header-nav li>ul>li", "font-size", "80%")
+  ) {
     errors.push("You didnt put a font-size of 80% on Article1 and Article2 in #header-nav");
   }
-  
+
   if (!ast.selector_has_property("#footer-nav","font-size","60%")) {
     errors.push("You didnt put a font-size of 60% on #footer-nav");
   }
-   
+
   if (!ast.selector_has_property("#footer-nav","padding-left","0px")) {
     errors.push("You didnt put a padding-left of 0px on #footer-nav");
   }
-  
+
   if (!ast.selector_has_property("h1.small","font-size","70%")) {
     errors.push("You didnt put a font-size of 70% on H1 with class small");
   }
-    
+
 }
 
 
@@ -49,4 +64,3 @@ else {
   process.stdout.write('\n');
   process.exit(1);
 }
-


### PR DESCRIPTION
The final challenge asks students to modify the CSS rules for list items nested within an unordered list within another list item, within an unordered list with an identifier.  The existing test looks for the CSS selector: _li ul_ only.  Since the challenge was for the "item", it would be more correct to specify the rule pointing to that item, i.e. _li ul li_.  The child selector would also work, i.e. _li>ul_ or _li>ul>li_.  

I added these and a few other options in the interest of avoiding student frustration and allowing multiple correct solutions based on the CSS selectors the students have been introduced to at this point.